### PR TITLE
Update redhat java builder-images from out-of-support RHEL7 versions

### DIFF
--- a/builder-images.md
+++ b/builder-images.md
@@ -7,8 +7,9 @@ Here is a non-exhaustive list of well maintained S2I builder images. Many more S
   - `registry.access.redhat.com/devtools/go-toolset-rhel7`
 
 - **java**
-  - `registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift`
-  - `registry.access.redhat.com/openjdk/openjdk-11-rhel7`
+  - `registry.access.redhat.com/ubi8/openjdk-8`
+  - `registry.access.redhat.com/ubi9/openjdk-11`
+  - `registry.access.redhat.com/ubi9/openjdk-17`
   - `fabric8/s2i-java`
 
 - **nodejs**


### PR DESCRIPTION
I'm the maintainer of the Red Hat OpenJDK container images. The two images of ours listed in builder-images.md are our earliest ones, based on RHEL7, which is in "extended maintenance phase 2" at the moment, and these images are no longer updated. Furthermore, although the images are publically accessible, this was a side-effect of the lack of support for authenticated registries in early tooling and they are not supported in any way without a redhat subscription (so e.g. package updates in downstream Dockerfiles would fail).

Instead I propose using the most recently available versions based on RHEL UBI 9, which offers JDK11 and 17. For completion's sake, include (as before) a JDK8 image, using RHEL UBI 8 (we don't provide a JDK8 image on RHEL9). All these images are in support, but they are also freely available under the UBI EULA, and do not require a redhat subscription to use.

This means replacing two images with three.