### PR TITLE
README: Fix URI for openshift-tools-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ building and running the source code.
 
 This Action will install [the latest](https://github.com/openshift/source-to-image/releases/tag/v1.3.1) version of S2I.
 
-To install any specific version of `s2i` use [**openshift-tools-installer**](https://github.com/marketplace/actions/openshift-client-installer).
-
+To install any specific version of `s2i` use [**openshift-tools-installer**](https://github.com/marketplace/actions/openshift-tools-installer).
 **NOTE:**
 `s2i-build` only works on Linux platforms, because it relies on the Docker daemon.<br>
 If you are using GitHub's Ubuntu runners, the Docker daemon will already be available.


### PR DESCRIPTION
The text referencing openshift-tools-installer actually linked to the deprecated openshift-client-installer.

<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description

Update the hyperlink from "openshift-tools-installer" to point at the openshift-tools-installer Marketplace page.

### Checklist

- [X] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [X] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [X] This change is a patch change
- [] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

README.md