### PR TITLE
fix: correct Sucessfully to Successfully typo in s2iExec.ts

### DIFF
--- a/src/s2iExec.ts
+++ b/src/s2iExec.ts
@@ -38,7 +38,7 @@ export async function run(): Promise<void> {
             throw new Error(getReason(s2iBinary));
         }
 
-        core.info(`✅ Sucessfully installed s2i.`);
+        core.info(`✅ Successfully installed s2i.`);
 
         s2iPath = s2iBinary.path;
     }


### PR DESCRIPTION
Fix typo in src/s2iExec.ts core.info message: Sucessfully -> Successfully.

Change: Line 41 - core.info message fix.

Why: User-visible output when s2i is installed.

Submitted via PR攻关 automation