### PR TITLE
Update CHANGELOG.md with v3 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # s2i-build Changelog
 
+## v3
+- Upgrade action runtime to Node24
+- Upgrade s2i to `v1.6.2` with tool-cache caching for faster builds
+- Switch to ESM output to fix `@actions/*` module resolution
+- Upgrade all dependencies to current stable versions (`@actions/core` v3, `@actions/exec` v3, `@actions/io` v3, `@actions/tool-cache` v4, TypeScript v6)
+- Fix docker tag bug and correct action metadata ([#61](https://github.com/redhat-actions/s2i-build/pull/61))
+- Modernize CI workflows to current GitHub Actions standards ([#60](https://github.com/redhat-actions/s2i-build/pull/60))
+- Add CODEOWNERS, SECURITY.md, and Dependabot configuration
+- Remove defunct CRDA code scanning workflow
+
 ## v2.4
 - Update s2i version to `v1.3.9`
 - Update action to run on Node20. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/


### PR DESCRIPTION
## Summary
- Add a v3 section to CHANGELOG.md documenting all changes since v2.4
- Covers Node24 runtime upgrade, s2i v1.6.2, ESM migration, dependency upgrades, CI modernization, and repo hygiene additions

## Test plan
- [ ] Verify changelog formatting renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)