### PR TITLE
Block Dependabot from proposing TypeScript 7 upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
           - "@actions/*"
       dev-dependencies:
         dependency-type: "development"
+    ignore:
+      - dependency-name: "typescript"
+        versions: [">=7"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Add an `ignore` rule to the npm Dependabot config to block TypeScript versions >=7

## Test plan
- [ ] Verify Dependabot no longer opens PRs for TypeScript 7.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)